### PR TITLE
chore: fix dev setup and document a quality getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,129 @@
 # InteliScrap
 A tool to help you build your very own custom computer with advanced component research and price comparison algorithms
 
+---
+
+## 🚀 Démarrage rapide
+
+Toute la stack (frontend, backend, base de données) tourne via Docker Compose.
+
+### Prérequis
+- [Docker](https://docs.docker.com/get-docker/) **≥ 24**
+- Docker Compose v2 (inclus dans Docker Desktop)
+- Les ports `5173`, `8000` et `5433` libres sur la machine hôte
+
+### Lancer le projet
+
+```bash
+git clone https://github.com/AugusteDollinger/InteliScrap.git
+cd InteliScrap
+./startup.sh                 # = docker compose -f infra-inteliscrap/docker-compose.yml up
+```
+
+Au premier lancement, les images sont construites (compter quelques minutes).
+Pour lancer en arrière-plan : ajouter `-d`.
+
+```bash
+docker compose -f infra-inteliscrap/docker-compose.yml up -d --build
+```
+
+### Vérifier que tout tourne
+
+```bash
+curl http://localhost:8000/health
+# -> {"status":"healthy","message":"InteliScrap API is running"}
+```
+
+### Services & URLs
+
+| Service   | URL                              | Détails                                  |
+|-----------|----------------------------------|------------------------------------------|
+| Frontend  | http://localhost:5173            | React 19 + Vite (HMR activé)             |
+| Backend   | http://localhost:8000            | FastAPI                                   |
+| API docs  | http://localhost:8000/docs       | Swagger UI auto-généré                    |
+| Health    | http://localhost:8000/health     | Sonde de disponibilité                    |
+| PostgreSQL| `localhost:5433`                 | Postgres 15 (DB interne sur `postgres:5432`) |
+
+> ℹ️ Le port hôte de Postgres est `5433` (et non `5432`) pour éviter tout conflit
+> avec une instance Postgres déjà présente sur la machine. À l'intérieur du réseau
+> Docker, le backend contacte la base via `postgres:5432`.
+
+### Compte par défaut
+
+Un administrateur est créé automatiquement au démarrage du backend :
+
+| Email                | Mot de passe |
+|----------------------|--------------|
+| `admin@example.com`  | `admin`      |
+
+> ⚠️ À usage de développement uniquement — à changer / désactiver avant toute mise en production.
+
+---
+
+## 🛠️ Développement
+
+### Commandes utiles
+
+```bash
+# Logs en direct
+docker compose -f infra-inteliscrap/docker-compose.yml logs -f backend
+docker compose -f infra-inteliscrap/docker-compose.yml logs -f frontend
+
+# Exécuter une commande dans un conteneur (helpers fournis)
+./back.sh <cmd>      # ex: ./back.sh alembic upgrade head
+./front.sh <cmd>     # ex: ./front.sh pnpm lint
+
+# Arrêter la stack
+docker compose -f infra-inteliscrap/docker-compose.yml down
+
+# Tout réinitialiser (⚠️ supprime les données de la base)
+docker compose -f infra-inteliscrap/docker-compose.yml down -v
+```
+
+### Migrations de base de données (Alembic)
+
+```bash
+./back.sh alembic upgrade head                       # appliquer les migrations
+./back.sh alembic revision --autogenerate -m "msg"   # générer une migration
+```
+
+### Structure du projet
+
+```
+InteliScrap/
+├── infra-inteliscrap/      # Docker Compose (orchestration des services)
+├── backend/                # API FastAPI
+│   ├── app/
+│   │   ├── api/            # Routes (v1)
+│   │   ├── models/         # Modèles SQLAlchemy
+│   │   ├── schemas/        # Schémas Pydantic
+│   │   ├── services/       # Logique métier
+│   │   ├── database.py     # Connexion DB
+│   │   └── main.py         # Point d'entrée FastAPI
+│   └── alembic/            # Migrations
+├── frontend/               # SPA React 19 + Vite + TypeScript
+│   └── src/
+├── back.sh / front.sh      # Helpers d'exécution dans les conteneurs
+└── startup.sh              # Lancement de la stack
+```
+
+### Stack technique
+
+- **Frontend** : React 19, TypeScript, Vite 7, React Router 7, Sass
+- **Backend** : FastAPI, SQLAlchemy 2, Alembic, Pydantic 2, Playwright (scraping)
+- **Base de données** : PostgreSQL 15
+- **Auth** : JWT (python-jose), hash de mot de passe Argon2
+
+### Dépannage
+
+| Problème | Solution |
+|----------|----------|
+| `Bind for 0.0.0.0:5432 failed: port is already allocated` | Un Postgres tourne déjà sur l'hôte ; le port DB est mappé sur `5433` (voir compose). |
+| Le backend ne build pas (`psycopg2-binary`) | L'image est épinglée sur `python:3.12-slim` (les wheels n'existent pas pour `python:latest`). |
+| Frontend inaccessible | Vérifier les logs : `docker compose ... logs -f frontend` (l'install pnpm a lieu au runtime). |
+
+---
+
 # Brief InteliScrap
 
 ## Concept

--- a/backend/dockerfile.dev
+++ b/backend/dockerfile.dev
@@ -1,4 +1,6 @@
-FROM python:latest
+# Pinned to 3.12: psycopg2-binary 2.9.9 ships no wheel for 3.14 (python:latest)
+# and source-builds fail against the CPython 3.14 C API.
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/infra-inteliscrap/docker-compose.yml
+++ b/infra-inteliscrap/docker-compose.yml
@@ -43,7 +43,9 @@ services:
       POSTGRES_PASSWORD: inteliscrap_password
       POSTGRES_DB: inteliscrap_db
     ports:
-      - "5432:5432"
+      # Host 5433 -> container 5432 to avoid clashing with a local Postgres.
+      # The backend reaches the DB via the internal network (postgres:5432).
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data/
 


### PR DESCRIPTION
## Description

Le projet ne démarrait pas en l'état via `docker compose`. Cette PR corrige le setup de dev et ajoute une vraie documentation de démarrage.

**Corrections (bloquantes au lancement) :**
- `backend/dockerfile.dev` : épingle `python:3.12-slim`. `python:latest` (= 3.14) n'a pas de wheel `psycopg2-binary==2.9.9` et la compilation depuis les sources échoue contre l'API C de CPython 3.14.
- `infra-inteliscrap/docker-compose.yml` : mappe le port hôte Postgres sur `5433` pour éviter le conflit avec une instance Postgres locale. Le backend continue de joindre la base via `postgres:5432` sur le réseau Docker interne.

**Documentation :**
- `README.md` : section setup de qualité — prérequis, démarrage rapide, tableau des services/URLs, compte admin par défaut, commandes de dev (logs, helpers, migrations Alembic), arborescence et dépannage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Stack lancée localement et endpoints vérifiés :
- `GET /health` → `{"status":"healthy",...}`
- `GET /api/v1/users` → admin seedé présent
- `GET /docs` → 200 (Swagger UI)
- Frontend Vite `http://localhost:5173` → 200

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)